### PR TITLE
Add STM32L031F6P6 charlieplexed binary watch firmware

### DIFF
--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -1,8 +1,8 @@
 [env:binary_watch]
 platform          = ststm32
-board             = nucleo_l031k6
+board             = genericSTM32L031F6
 framework         = hal
-board_build.mcu   = stm32l031d6px
+board_build.mcu   = stm32l031f6p6
 board_build.f_cpu = 16000000L
 upload_protocol   = stlink
 debug_tool        = stlink


### PR DESCRIPTION
## Summary
- New `stm32/` PlatformIO project (HAL framework) targeting **STM32L031F6P6** (TSSOP20)
- 14-LED charlieplex display on PA0–PA4 driven by a 1 kHz TIM2 scan
- BCD time display (hours/minutes), RTC on LSE, battery measurement via internal VREFINT
- Buttons on PA5/PA6 (EXTI4_15) with short/long press detection and software debounce
- Stop-mode idle with EXTI wakeup; full state machine: startup animation, show time, set time, show battery, sleep

## Test plan
- [ ] Build with `pio run` in `stm32/`
- [ ] Flash via ST-Link and verify startup LED sweep
- [ ] Verify time display and button short/long press behavior
- [ ] Verify Stop-mode wakeup on button press
- [ ] Verify battery percentage display

https://claude.ai/code/session_01WgjdJ1qohaZV74CJ2ntiFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgjdJ1qohaZV74CJ2ntiFC)_